### PR TITLE
지도 위에 포켓몬 서식지 마커 띄우기 작업 완료

### DIFF
--- a/PokemonDictionary/PokemonDictionary.xcodeproj/project.pbxproj
+++ b/PokemonDictionary/PokemonDictionary.xcodeproj/project.pbxproj
@@ -34,6 +34,8 @@
 		B4A3ACFA26BF68AA00A5C7E0 /* PokemonMapViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4A3ACF826BF68AA00A5C7E0 /* PokemonMapViewController.swift */; };
 		B4A3ACFB26BF68AA00A5C7E0 /* PokemonMapViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = B4A3ACF926BF68AA00A5C7E0 /* PokemonMapViewController.xib */; };
 		B4A3ACFD26BF6A4A00A5C7E0 /* MapViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4A3ACFC26BF6A4A00A5C7E0 /* MapViewModel.swift */; };
+		B4A3ACFF26BFC1EB00A5C7E0 /* PokemonAnnotationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4A3ACFE26BFC1EB00A5C7E0 /* PokemonAnnotationView.swift */; };
+		B4A3AD0126C0008600A5C7E0 /* Coorinate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4A3AD0026C0008600A5C7E0 /* Coorinate.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -66,6 +68,8 @@
 		B4A3ACF826BF68AA00A5C7E0 /* PokemonMapViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PokemonMapViewController.swift; sourceTree = "<group>"; };
 		B4A3ACF926BF68AA00A5C7E0 /* PokemonMapViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = PokemonMapViewController.xib; sourceTree = "<group>"; };
 		B4A3ACFC26BF6A4A00A5C7E0 /* MapViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapViewModel.swift; sourceTree = "<group>"; };
+		B4A3ACFE26BFC1EB00A5C7E0 /* PokemonAnnotationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PokemonAnnotationView.swift; sourceTree = "<group>"; };
+		B4A3AD0026C0008600A5C7E0 /* Coorinate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Coorinate.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -179,7 +183,9 @@
 		B4A3ACF726BF687A00A5C7E0 /* Map */ = {
 			isa = PBXGroup;
 			children = (
+				B4A3AD0026C0008600A5C7E0 /* Coorinate.swift */,
 				B4A3ACFC26BF6A4A00A5C7E0 /* MapViewModel.swift */,
+				B4A3ACFE26BFC1EB00A5C7E0 /* PokemonAnnotationView.swift */,
 				B4A3ACF826BF68AA00A5C7E0 /* PokemonMapViewController.swift */,
 				B4A3ACF926BF68AA00A5C7E0 /* PokemonMapViewController.xib */,
 			);
@@ -266,10 +272,12 @@
 				B4955C2326BBE7C700AA1835 /* SearchViewController.swift in Sources */,
 				B4877C6826BCCCAA00647823 /* ListExtension.swift in Sources */,
 				B4877C7426BCEC6500647823 /* InputView.swift in Sources */,
+				B4A3AD0126C0008600A5C7E0 /* Coorinate.swift in Sources */,
 				B4955C3426BBEB0D00AA1835 /* Resource.swift in Sources */,
 				B4877C6526BCCC1A00647823 /* PokemonNameCell.swift in Sources */,
 				B492B81326BEAF120066CCBE /* PokemonDetailsViewController.swift in Sources */,
 				B4955C1F26BBE7C700AA1835 /* AppDelegate.swift in Sources */,
+				B4A3ACFF26BFC1EB00A5C7E0 /* PokemonAnnotationView.swift in Sources */,
 				B4877C7226BCDFB900647823 /* SearchedPokemon.swift in Sources */,
 				B4A3ACFD26BF6A4A00A5C7E0 /* MapViewModel.swift in Sources */,
 				B4A3ACFA26BF68AA00A5C7E0 /* PokemonMapViewController.swift in Sources */,

--- a/PokemonDictionary/PokemonDictionary.xcodeproj/project.pbxproj
+++ b/PokemonDictionary/PokemonDictionary.xcodeproj/project.pbxproj
@@ -31,6 +31,9 @@
 		B4955C3D26BC2D2E00AA1835 /* PokemonLocations.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4955C3C26BC2D2E00AA1835 /* PokemonLocations.swift */; };
 		B4955C3F26BC2EDA00AA1835 /* PokemonDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4955C3E26BC2EDA00AA1835 /* PokemonDetail.swift */; };
 		B4955C4226BC34A300AA1835 /* SearchViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4955C4126BC34A300AA1835 /* SearchViewModel.swift */; };
+		B4A3ACFA26BF68AA00A5C7E0 /* PokemonMapViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4A3ACF826BF68AA00A5C7E0 /* PokemonMapViewController.swift */; };
+		B4A3ACFB26BF68AA00A5C7E0 /* PokemonMapViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = B4A3ACF926BF68AA00A5C7E0 /* PokemonMapViewController.xib */; };
+		B4A3ACFD26BF6A4A00A5C7E0 /* MapViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4A3ACFC26BF6A4A00A5C7E0 /* MapViewModel.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -60,6 +63,9 @@
 		B4955C3C26BC2D2E00AA1835 /* PokemonLocations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PokemonLocations.swift; sourceTree = "<group>"; };
 		B4955C3E26BC2EDA00AA1835 /* PokemonDetail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PokemonDetail.swift; sourceTree = "<group>"; };
 		B4955C4126BC34A300AA1835 /* SearchViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchViewModel.swift; sourceTree = "<group>"; };
+		B4A3ACF826BF68AA00A5C7E0 /* PokemonMapViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PokemonMapViewController.swift; sourceTree = "<group>"; };
+		B4A3ACF926BF68AA00A5C7E0 /* PokemonMapViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = PokemonMapViewController.xib; sourceTree = "<group>"; };
+		B4A3ACFC26BF6A4A00A5C7E0 /* MapViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapViewModel.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -115,6 +121,7 @@
 				B4955C3226BBEAF500AA1835 /* API */,
 				B4955C4026BC349000AA1835 /* Search */,
 				B498DA5126BE4E1C00ED4EB2 /* PokemonDetails */,
+				B4A3ACF726BF687A00A5C7E0 /* Map */,
 				B4955C1E26BBE7C700AA1835 /* AppDelegate.swift */,
 				B4955C2026BBE7C700AA1835 /* SceneDelegate.swift */,
 				B4955C2426BBE7C700AA1835 /* Main.storyboard */,
@@ -167,6 +174,16 @@
 				B492B81226BEAF120066CCBE /* PokemonDetailsViewController.xib */,
 			);
 			path = PokemonDetails;
+			sourceTree = "<group>";
+		};
+		B4A3ACF726BF687A00A5C7E0 /* Map */ = {
+			isa = PBXGroup;
+			children = (
+				B4A3ACFC26BF6A4A00A5C7E0 /* MapViewModel.swift */,
+				B4A3ACF826BF68AA00A5C7E0 /* PokemonMapViewController.swift */,
+				B4A3ACF926BF68AA00A5C7E0 /* PokemonMapViewController.xib */,
+			);
+			path = Map;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -228,6 +245,7 @@
 			files = (
 				B492B81426BEAF120066CCBE /* PokemonDetailsViewController.xib in Resources */,
 				B4955C2B26BBE7C800AA1835 /* LaunchScreen.storyboard in Resources */,
+				B4A3ACFB26BF68AA00A5C7E0 /* PokemonMapViewController.xib in Resources */,
 				B4955C2826BBE7C800AA1835 /* Assets.xcassets in Resources */,
 				B4877C6626BCCC1A00647823 /* PokemonNameCell.xib in Resources */,
 				B4955C2626BBE7C700AA1835 /* Main.storyboard in Resources */,
@@ -253,6 +271,8 @@
 				B492B81326BEAF120066CCBE /* PokemonDetailsViewController.swift in Sources */,
 				B4955C1F26BBE7C700AA1835 /* AppDelegate.swift in Sources */,
 				B4877C7226BCDFB900647823 /* SearchedPokemon.swift in Sources */,
+				B4A3ACFD26BF6A4A00A5C7E0 /* MapViewModel.swift in Sources */,
+				B4A3ACFA26BF68AA00A5C7E0 /* PokemonMapViewController.swift in Sources */,
 				B4896A4E26BED8E100415AC0 /* LoadingImageView.swift in Sources */,
 				B4955C2126BBE7C700AA1835 /* SceneDelegate.swift in Sources */,
 				B4955C4226BC34A300AA1835 /* SearchViewModel.swift in Sources */,

--- a/PokemonDictionary/PokemonDictionary/Map/Coorinate.swift
+++ b/PokemonDictionary/PokemonDictionary/Map/Coorinate.swift
@@ -1,0 +1,34 @@
+//
+//  Coorinate.swift
+//  PokemonDictionary
+//
+//  Created by Dayeon Jung on 2021/08/08.
+//
+
+import MapKit
+import UIKit
+
+class Coorinate: NSObject, MKAnnotation {
+    
+    private var latitude: CLLocationDegrees
+    private var longitude: CLLocationDegrees
+
+    var coordinate: CLLocationCoordinate2D {
+        get {
+            return CLLocationCoordinate2D(latitude: self.latitude,
+                                          longitude: self.longitude)
+        }
+        set {
+            self.latitude = newValue.latitude
+            self.longitude = newValue.longitude
+        }
+    }
+    
+    init(latitude: CLLocationDegrees,
+         longitude: CLLocationDegrees) {
+        self.latitude = latitude
+        self.longitude = longitude
+    }
+    
+    
+}

--- a/PokemonDictionary/PokemonDictionary/Map/MapViewModel.swift
+++ b/PokemonDictionary/PokemonDictionary/Map/MapViewModel.swift
@@ -1,0 +1,39 @@
+//
+//  MapViewModel.swift
+//  PokemonDictionary
+//
+//  Created by Dayeon Jung on 2021/08/08.
+//
+
+import Foundation
+import MapKit
+
+struct MapViewModel {
+    
+    let coordinate: [CLLocationCoordinate2D]
+    let centerCoordi: CLLocationCoordinate2D
+    let maxDistance: CLLocationDistance?
+    
+    init(locations: [(Double, Double)]) {
+        self.coordinate = locations.map({ CLLocationCoordinate2D(latitude: $0.0,
+                                                                 longitude: $0.1)} )
+        
+        let centerLat = locations.map({$0.0}).reduce(0, +)/Double(locations.count)
+        let centerLng = locations.map({$0.1}).reduce(0, +)/Double(locations.count)
+        self.centerCoordi = CLLocationCoordinate2D(latitude: centerLat,
+                                                   longitude: centerLng)
+        
+        let centerLocation = CLLocation(latitude: centerLat,
+                                        longitude: centerLng)
+        let clLocations = locations.map({ CLLocation(latitude: $0.0,
+                                                     longitude: $0.1)})
+        let maxDistance = clLocations.map({ $0.distance(from: centerLocation) }).max()
+        
+        let width = UIScreen.main.bounds.width
+        let height = UIScreen.main.bounds.height
+        let ratio = width > height ? width / height : height / width
+        self.maxDistance = maxDistance.map({ $0 * Double(ratio) })
+        
+    }
+    
+}

--- a/PokemonDictionary/PokemonDictionary/Map/MapViewModel.swift
+++ b/PokemonDictionary/PokemonDictionary/Map/MapViewModel.swift
@@ -10,14 +10,23 @@ import MapKit
 
 struct MapViewModel {
     
-    let coordinate: [CLLocationCoordinate2D]
-    let centerCoordi: CLLocationCoordinate2D
-    let maxDistance: CLLocationDistance?
+    let coordinates: [Coorinate]
+    private let centerCoordi: CLLocationCoordinate2D
+    private let maxDistance: CLLocationDistance?
+    
+    var region: MKCoordinateRegion {
+        guard let maxDistance = self.maxDistance else {
+            return MKCoordinateRegion()
+        }
+        return MKCoordinateRegion(center: self.centerCoordi,
+                                  latitudinalMeters: maxDistance,
+                                  longitudinalMeters: maxDistance)
+    }
     
     init(locations: [(Double, Double)]) {
-        self.coordinate = locations.map({ CLLocationCoordinate2D(latitude: $0.0,
-                                                                 longitude: $0.1)} )
         
+        self.coordinates = locations.map({Coorinate(latitude: $0.0, longitude: $0.1)})
+
         let centerLat = locations.map({$0.0}).reduce(0, +)/Double(locations.count)
         let centerLng = locations.map({$0.1}).reduce(0, +)/Double(locations.count)
         self.centerCoordi = CLLocationCoordinate2D(latitude: centerLat,
@@ -26,7 +35,7 @@ struct MapViewModel {
         let centerLocation = CLLocation(latitude: centerLat,
                                         longitude: centerLng)
         let clLocations = locations.map({ CLLocation(latitude: $0.0,
-                                                     longitude: $0.1)})
+                                                     longitude: $0.1) })
         let maxDistance = clLocations.map({ $0.distance(from: centerLocation) }).max()
         
         let width = UIScreen.main.bounds.width

--- a/PokemonDictionary/PokemonDictionary/Map/PokemonAnnotationView.swift
+++ b/PokemonDictionary/PokemonDictionary/Map/PokemonAnnotationView.swift
@@ -1,0 +1,39 @@
+//
+//  PokemonAnnotationView.swift
+//  PokemonDictionary
+//
+//  Created by Dayeon Jung on 2021/08/08.
+//
+
+import MapKit
+
+class PokemonAnnotationView: MKMarkerAnnotationView {
+    
+    static let reuseID = "pokemonAnnotation"
+    
+    override init(annotation: MKAnnotation?,
+                  reuseIdentifier: String?) {
+        super.init(annotation: annotation, reuseIdentifier: reuseIdentifier)
+        clusteringIdentifier = "pokemon"
+    }
+        
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func prepareForDisplay() {
+        super.prepareForDisplay()
+        displayPriority = .defaultLow
+        markerTintColor = .systemYellow
+        
+        if let cluster = annotation as? MKClusterAnnotation {
+            let total = cluster.memberAnnotations.count
+            glyphText = "\(total)"
+        } else {
+            glyphText = "1"
+        }
+        
+    }
+    
+
+}

--- a/PokemonDictionary/PokemonDictionary/Map/PokemonMapViewController.swift
+++ b/PokemonDictionary/PokemonDictionary/Map/PokemonMapViewController.swift
@@ -16,7 +16,11 @@ class PokemonMapViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        self.setMapView(coordinates: self.viewModel.coordinate)
+        self.mapView.delegate = self
+        self.mapView.register(PokemonAnnotationView.self,
+                              forAnnotationViewWithReuseIdentifier: MKMapViewDefaultAnnotationViewReuseIdentifier)
+
+        self.setMapView()
 
     }
 
@@ -25,28 +29,16 @@ class PokemonMapViewController: UIViewController {
     }
     
     
-    private func setMapView(coordinates: [CLLocationCoordinate2D]) {
-        
-        guard let maxDistance = self.viewModel.maxDistance else { return }
-        let region = MKCoordinateRegion(center: self.viewModel.centerCoordi,
-                                        latitudinalMeters: maxDistance,
-                                        longitudinalMeters: maxDistance)
-        self.mapView.setRegion(region, animated: true)
-        
-        _ = coordinates.map({
-            self.addAnnotation(coordinate: $0)
-        })
-        
+    private func setMapView() {
+        self.mapView.setRegion(self.viewModel.region, animated: true)
+        self.mapView.addAnnotations(self.viewModel.coordinates)
     }
     
-    
-    private func addAnnotation(coordinate: CLLocationCoordinate2D){
-        let annotation = MKPointAnnotation()
-        annotation.coordinate = coordinate
-        self.mapView.addAnnotation(annotation)
-        
+}
+
+extension PokemonMapViewController: MKMapViewDelegate {
+    func mapView(_ mapView: MKMapView, viewFor annotation: MKAnnotation) -> MKAnnotationView? {
+        return PokemonAnnotationView(annotation: annotation,
+                                     reuseIdentifier: PokemonAnnotationView.reuseID)
     }
-    
-    
-    
 }

--- a/PokemonDictionary/PokemonDictionary/Map/PokemonMapViewController.swift
+++ b/PokemonDictionary/PokemonDictionary/Map/PokemonMapViewController.swift
@@ -1,0 +1,52 @@
+//
+//  PokemonMapViewController.swift
+//  PokemonDictionary
+//
+//  Created by Dayeon Jung on 2021/08/08.
+//
+
+import UIKit
+import MapKit
+
+class PokemonMapViewController: UIViewController {
+
+    @IBOutlet weak var mapView: MKMapView!
+    var viewModel: MapViewModel! 
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        self.setMapView(coordinates: self.viewModel.coordinate)
+
+    }
+
+    @IBAction func dismiss(_ sender: Any) {
+        self.dismiss(animated: true, completion: nil)
+    }
+    
+    
+    private func setMapView(coordinates: [CLLocationCoordinate2D]) {
+        
+        guard let maxDistance = self.viewModel.maxDistance else { return }
+        let region = MKCoordinateRegion(center: self.viewModel.centerCoordi,
+                                        latitudinalMeters: maxDistance,
+                                        longitudinalMeters: maxDistance)
+        self.mapView.setRegion(region, animated: true)
+        
+        _ = coordinates.map({
+            self.addAnnotation(coordinate: $0)
+        })
+        
+    }
+    
+    
+    private func addAnnotation(coordinate: CLLocationCoordinate2D){
+        let annotation = MKPointAnnotation()
+        annotation.coordinate = coordinate
+        self.mapView.addAnnotation(annotation)
+        
+    }
+    
+    
+    
+}

--- a/PokemonDictionary/PokemonDictionary/Map/PokemonMapViewController.xib
+++ b/PokemonDictionary/PokemonDictionary/Map/PokemonMapViewController.xib
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="PokemonMapViewController" customModule="PokemonDictionary" customModuleProvider="target">
+            <connections>
+                <outlet property="mapView" destination="cuu-ZU-sz3" id="HIO-N0-dDa"/>
+                <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="i5M-Pr-FkT">
+            <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <mapView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" mapType="standard" translatesAutoresizingMaskIntoConstraints="NO" id="cuu-ZU-sz3">
+                    <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                </mapView>
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="TKq-OU-czs">
+                    <rect key="frame" x="12" y="44" width="52" height="52"/>
+                    <constraints>
+                        <constraint firstAttribute="width" constant="52" id="ECG-uO-cus"/>
+                        <constraint firstAttribute="height" constant="52" id="m1s-Cn-VHb"/>
+                    </constraints>
+                    <fontDescription key="fontDescription" type="system" weight="medium" pointSize="16"/>
+                    <state key="normal" title="닫기">
+                        <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                    </state>
+                    <connections>
+                        <action selector="dismiss:" destination="-1" eventType="touchUpInside" id="sIP-SB-wbu"/>
+                    </connections>
+                </button>
+            </subviews>
+            <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
+            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+            <constraints>
+                <constraint firstItem="cuu-ZU-sz3" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="3Bw-bi-3pj"/>
+                <constraint firstItem="TKq-OU-czs" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" id="6Pe-GM-8CV"/>
+                <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="cuu-ZU-sz3" secondAttribute="trailing" id="EHJ-Je-Y9R"/>
+                <constraint firstAttribute="bottom" secondItem="cuu-ZU-sz3" secondAttribute="bottom" id="InE-GF-4S1"/>
+                <constraint firstItem="cuu-ZU-sz3" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="top" id="Umt-Xl-vD4"/>
+                <constraint firstItem="TKq-OU-czs" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="12" id="iKK-ue-p0A"/>
+            </constraints>
+            <point key="canvasLocation" x="75" y="144"/>
+        </view>
+    </objects>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/PokemonDictionary/PokemonDictionary/PokemonDetails/PokemonDetailsViewController.swift
+++ b/PokemonDictionary/PokemonDictionary/PokemonDetails/PokemonDetailsViewController.swift
@@ -30,9 +30,17 @@ class PokemonDetailsViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         self.stackView.alpha = 0
+        
+        self.locationsButton.addTarget(self, action: #selector(self.moveToMapVC), for: .touchUpInside)
     }
 
 
+    @objc func moveToMapVC() {
+        let destVC = PokemonMapViewController(nibName: "PokemonMapViewController", bundle: nil)
+        destVC.viewModel = MapViewModel(locations: self.viewModel.locationInfos())
+        self.present(destVC, animated: true, completion: nil)
+    }
+    
     func updateStackViewUI() {
         guard let stackView = self.stackView else { return }
         

--- a/PokemonDictionary/PokemonDictionary/PokemonDetails/PokemonDetailsViewModel.swift
+++ b/PokemonDictionary/PokemonDictionary/PokemonDetails/PokemonDetailsViewModel.swift
@@ -97,4 +97,8 @@ extension PokemonDetailsViewModel {
     func hasHabitat() -> Bool {
         return !self.locations.isEmpty
     }
+    
+    func locationInfos() -> [(Double, Double)] {
+        return self.locations
+    }
 }


### PR DESCRIPTION
* 위도, 경도 정보로 마커를 표시합니다.
* 최대한 한 눈에 모든 서식지의 위치를 확인하기에 알맞은 zoom값을 초기에 세팅합니다.
* 지역이 겹쳐 클러스터링될 때, 중복된 숫자를 함께 표기합니다.