### PR TITLE
포켓몬 상세화면을 Bottom Sheet UI로 변경.

### DIFF
--- a/PokemonDictionary/PokemonDictionary/LoadingImageView.swift
+++ b/PokemonDictionary/PokemonDictionary/LoadingImageView.swift
@@ -10,7 +10,7 @@ import UIKit
 
 class LoadingImageView: UIImageView {
     
-    func loadImage(with urlString: String) {
+    func loadImage(with urlString: String, completion: @escaping (() -> Void)) {
         let width = self.frame.size.width
         let targetSize = CGSize(width: width,
                                 height: width)
@@ -29,6 +29,7 @@ class LoadingImageView: UIImageView {
                     let resized = self.resizeImage(image: loadedImage,
                                                    targetSize: targetSize)
                     self.image = resized
+                    completion()
                 }
                 
             case .failure(let error):

--- a/PokemonDictionary/PokemonDictionary/PokemonDetails/PokemonDetailsViewController.swift
+++ b/PokemonDictionary/PokemonDictionary/PokemonDetails/PokemonDetailsViewController.swift
@@ -9,6 +9,9 @@ import UIKit
 
 class PokemonDetailsViewController: UIViewController {
 
+    @IBOutlet weak var dimmedView: UIView!
+    @IBOutlet weak var containerView: UIView!
+    
     @IBOutlet weak var stackView: UIStackView!
     
     @IBOutlet weak var imageView: LoadingImageView!
@@ -17,6 +20,13 @@ class PokemonDetailsViewController: UIViewController {
     @IBOutlet weak var weightLabel: UILabel!
     @IBOutlet weak var locationsButton: UIButton!
     
+    @IBOutlet weak var containerViewHeightConstraint: NSLayoutConstraint!
+    @IBOutlet weak var containerViewBottomConstraint: NSLayoutConstraint!
+    
+    let maxDimmedAlpha: CGFloat = 0.6
+    var defaultHeight: CGFloat = 580
+    let dismissibleHeight: CGFloat = 200
+
     var viewModel: PokemonDetailsViewModel! {
         didSet {
             self.viewModel.updateStackView = {
@@ -29,20 +39,67 @@ class PokemonDetailsViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        self.stackView.alpha = 0
+
+        self.view.backgroundColor = .clear
         
-        self.locationsButton.addTarget(self, action: #selector(self.moveToMapVC), for: .touchUpInside)
-    }
+        self.containerView.layer.cornerRadius = 16
+        self.containerView.clipsToBounds = true
+        self.dimmedView.alpha = self.maxDimmedAlpha
 
+        self.setLocationButtonEvent()
+        self.setTapGesture()
+        self.setupPanGesture()
 
-    @objc func moveToMapVC() {
-        let destVC = PokemonMapViewController(nibName: "PokemonMapViewController", bundle: nil)
-        destVC.viewModel = MapViewModel(locations: self.viewModel.locationInfos())
-        self.present(destVC, animated: true, completion: nil)
     }
     
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+
+        self.animateShowDimmedView()
+        self.animatePresentContainer()
+    }
+    
+    func animateShowDimmedView() {
+        dimmedView.alpha = 0
+        UIView.animate(withDuration: 0.4) {
+            self.dimmedView.alpha = self.maxDimmedAlpha
+        }
+    }
+    
+    func animatePresentContainer() {
+        UIView.animate(withDuration: 0.3) {
+            self.containerViewBottomConstraint?.constant = 0
+            self.view.layoutIfNeeded()
+        }
+        defaultHeight = self.stackView.bounds.height
+    }
+    
+    
+    func animateContainerHeight(_ height: CGFloat) {
+        UIView.animate(withDuration: 0.4) {
+            self.containerViewHeightConstraint?.constant = height
+            self.view.layoutIfNeeded()
+        }
+        defaultHeight = height
+    }
+    
+    private func animateDismissView() {
+        UIView.animate(withDuration: 0.3) {
+            self.containerViewBottomConstraint?.constant = self.defaultHeight
+            self.view.layoutIfNeeded()
+        }
+        
+        dimmedView.alpha = maxDimmedAlpha
+        UIView.animate(withDuration: 0.4) {
+            self.dimmedView.alpha = 0
+        } completion: { _ in
+            self.dismiss(animated: false)
+        }
+    }
+
+    
     func updateStackViewUI() {
-        guard let stackView = self.stackView else { return }
+        guard let _ = self.stackView else { return }
         
         self.nameLabel.text = "이름 : " + self.viewModel.namesOfPokemon()
         self.heightLabel.text = "키 : " + self.viewModel.heightOfPokemon()
@@ -50,14 +107,72 @@ class PokemonDetailsViewController: UIViewController {
         self.locationsButton.isHidden = !self.viewModel.hasHabitat()
 
         if let imageStr = self.viewModel.imageString() {
-            self.imageView.loadImage(with: imageStr)
+            self.imageView.loadImage(with: imageStr) {
+                let updatedStackViewHeight = self.stackView.bounds.height
+                if self.defaultHeight != updatedStackViewHeight {
+                    self.animateContainerHeight(updatedStackViewHeight)
+                }
+            }
         } else {
             self.imageView.isHidden = true
         }
-                
-        UIView.animate(withDuration: 0.5) {
-            stackView.alpha = 1
-        }
+
     }
     
+}
+
+extension PokemonDetailsViewController {
+    
+    private func setLocationButtonEvent() {
+        self.locationsButton.addTarget(self, action: #selector(self.moveToMapVC),
+                                       for: .touchUpInside)
+    }
+    
+    @objc func moveToMapVC() {
+        let destVC = PokemonMapViewController(nibName: "PokemonMapViewController", bundle: nil)
+        destVC.viewModel = MapViewModel(locations: self.viewModel.locationInfos())
+        self.present(destVC, animated: true, completion: nil)
+    }
+    
+    private func setTapGesture() {
+        let tapGesture = UITapGestureRecognizer(target: self,
+                                                action: #selector(self.handleTapGesture))
+        self.dimmedView.addGestureRecognizer(tapGesture)
+    }
+    
+    @objc func handleTapGesture() {
+        self.animateDismissView()
+    }
+    
+    private func setupPanGesture() {
+        let panGesture = UIPanGestureRecognizer(target: self,
+                                                action: #selector(self.handlePanGesture(gesture:)))
+        // change to false to immediately listen on gesture movement
+        panGesture.delaysTouchesBegan = false
+        panGesture.delaysTouchesEnded = false
+        self.view.addGestureRecognizer(panGesture)
+    }
+
+    @objc func handlePanGesture(gesture: UIPanGestureRecognizer) {
+        let translation = gesture.translation(in: view)
+        let newHeight = defaultHeight - translation.y
+        
+        switch gesture.state {
+        case .changed:
+            if newHeight < defaultHeight {
+                containerViewHeightConstraint?.constant = newHeight
+                view.layoutIfNeeded()
+            }
+            
+        case .ended:
+            if newHeight < dismissibleHeight {
+                self.animateDismissView()
+            } else if newHeight < defaultHeight {
+                animateContainerHeight(defaultHeight)
+            }
+            
+        default:
+            break
+        }
+    }
 }

--- a/PokemonDictionary/PokemonDictionary/PokemonDetails/PokemonDetailsViewController.xib
+++ b/PokemonDictionary/PokemonDictionary/PokemonDetails/PokemonDetailsViewController.xib
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
@@ -10,6 +10,10 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="PokemonDetailsViewController" customModule="PokemonDictionary" customModuleProvider="target">
             <connections>
+                <outlet property="containerView" destination="dMV-bm-I6E" id="FYY-fC-kao"/>
+                <outlet property="containerViewBottomConstraint" destination="cKF-Q8-oHT" id="rQp-PJ-fh9"/>
+                <outlet property="containerViewHeightConstraint" destination="8FM-xZ-6QJ" id="gSO-oI-TnR"/>
+                <outlet property="dimmedView" destination="teW-tz-jpw" id="9Cf-Mu-2VV"/>
                 <outlet property="heightLabel" destination="pwn-j8-nJc" id="StP-cv-PBk"/>
                 <outlet property="imageView" destination="0T8-Uq-hw2" id="X3w-hE-m1G"/>
                 <outlet property="locationsButton" destination="TCK-eL-kHY" id="4eO-VR-ApZ"/>
@@ -21,72 +25,92 @@
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="i5M-Pr-FkT">
-            <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+            <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="center" spacing="40" translatesAutoresizingMaskIntoConstraints="NO" id="UmH-6k-ovo">
-                    <rect key="frame" x="0.0" y="44" width="414" height="699.5"/>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="teW-tz-jpw" userLabel="dimmedView">
+                    <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                    <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                </view>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="dMV-bm-I6E" userLabel="containerView">
+                    <rect key="frame" x="0.0" y="667.5" width="375" height="579.5"/>
                     <subviews>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="상세보기" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="E7O-gN-9lh">
-                            <rect key="frame" x="165.5" y="32" width="83.5" height="33.5"/>
+                        <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="center" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="UmH-6k-ovo">
+                            <rect key="frame" x="0.0" y="0.0" width="375" height="579.5"/>
+                            <subviews>
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="상세보기" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="E7O-gN-9lh">
+                                    <rect key="frame" x="146" y="32" width="83.5" height="33.5"/>
+                                    <constraints>
+                                        <constraint firstAttribute="height" constant="33.5" id="Zpz-Lo-GIZ"/>
+                                    </constraints>
+                                    <fontDescription key="fontDescription" type="system" weight="heavy" pointSize="24"/>
+                                    <nil key="textColor"/>
+                                    <nil key="highlightedColor"/>
+                                </label>
+                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" verticalHuggingPriority="249" verticalCompressionResistancePriority="749" translatesAutoresizingMaskIntoConstraints="NO" id="0T8-Uq-hw2" customClass="LoadingImageView" customModule="PokemonDictionary" customModuleProvider="target">
+                                    <rect key="frame" x="47.5" y="81.5" width="280" height="280"/>
+                                    <constraints>
+                                        <constraint firstAttribute="width" constant="280" id="NwF-LK-AY5"/>
+                                    </constraints>
+                                </imageView>
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="이름 :" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="YQi-oT-xQp">
+                                    <rect key="frame" x="165" y="377.5" width="45" height="24"/>
+                                    <fontDescription key="fontDescription" type="system" pointSize="20"/>
+                                    <nil key="textColor"/>
+                                    <nil key="highlightedColor"/>
+                                </label>
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="키 :" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pwn-j8-nJc">
+                                    <rect key="frame" x="174" y="417.5" width="27.5" height="24"/>
+                                    <fontDescription key="fontDescription" type="system" pointSize="20"/>
+                                    <nil key="textColor"/>
+                                    <nil key="highlightedColor"/>
+                                </label>
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="몸무게 :" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="yhn-6h-BL4">
+                                    <rect key="frame" x="156.5" y="457.5" width="62" height="24"/>
+                                    <fontDescription key="fontDescription" type="system" pointSize="20"/>
+                                    <nil key="textColor"/>
+                                    <nil key="highlightedColor"/>
+                                </label>
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="TCK-eL-kHY">
+                                    <rect key="frame" x="20" y="497.5" width="335" height="50"/>
+                                    <color key="backgroundColor" systemColor="systemYellowColor"/>
+                                    <constraints>
+                                        <constraint firstAttribute="height" constant="50" id="9JK-X8-OXq"/>
+                                    </constraints>
+                                    <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="15"/>
+                                    <state key="normal" title="서식지 보기">
+                                        <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                    </state>
+                                </button>
+                            </subviews>
+                            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                             <constraints>
-                                <constraint firstAttribute="height" constant="33.5" id="Zpz-Lo-GIZ"/>
+                                <constraint firstAttribute="trailing" secondItem="TCK-eL-kHY" secondAttribute="trailing" constant="20" id="Fba-w5-3ed"/>
+                                <constraint firstItem="TCK-eL-kHY" firstAttribute="leading" secondItem="UmH-6k-ovo" secondAttribute="leading" constant="20" id="Fo7-bM-ZzX"/>
                             </constraints>
-                            <fontDescription key="fontDescription" type="system" weight="heavy" pointSize="24"/>
-                            <nil key="textColor"/>
-                            <nil key="highlightedColor"/>
-                        </label>
-                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" verticalHuggingPriority="249" verticalCompressionResistancePriority="749" translatesAutoresizingMaskIntoConstraints="NO" id="0T8-Uq-hw2" customClass="LoadingImageView" customModule="PokemonDictionary" customModuleProvider="target">
-                            <rect key="frame" x="67" y="105.5" width="280" height="280"/>
-                            <constraints>
-                                <constraint firstAttribute="width" constant="280" id="NwF-LK-AY5"/>
-                            </constraints>
-                        </imageView>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="이름 :" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="YQi-oT-xQp">
-                            <rect key="frame" x="184.5" y="425.5" width="45" height="24"/>
-                            <fontDescription key="fontDescription" type="system" pointSize="20"/>
-                            <nil key="textColor"/>
-                            <nil key="highlightedColor"/>
-                        </label>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="키 :" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pwn-j8-nJc">
-                            <rect key="frame" x="193.5" y="489.5" width="27.5" height="24"/>
-                            <fontDescription key="fontDescription" type="system" pointSize="20"/>
-                            <nil key="textColor"/>
-                            <nil key="highlightedColor"/>
-                        </label>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="몸무게 :" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="yhn-6h-BL4">
-                            <rect key="frame" x="176" y="553.5" width="62" height="24"/>
-                            <fontDescription key="fontDescription" type="system" pointSize="20"/>
-                            <nil key="textColor"/>
-                            <nil key="highlightedColor"/>
-                        </label>
-                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="TCK-eL-kHY">
-                            <rect key="frame" x="20" y="617.5" width="374" height="50"/>
-                            <color key="backgroundColor" systemColor="systemYellowColor"/>
-                            <constraints>
-                                <constraint firstAttribute="height" constant="50" id="9JK-X8-OXq"/>
-                            </constraints>
-                            <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="15"/>
-                            <state key="normal" title="서식지 보기">
-                                <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                            </state>
-                        </button>
+                            <directionalEdgeInsets key="directionalLayoutMargins" top="32" leading="20" bottom="32" trailing="20"/>
+                        </stackView>
                     </subviews>
-                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     <constraints>
-                        <constraint firstAttribute="trailing" secondItem="TCK-eL-kHY" secondAttribute="trailing" constant="20" id="Fba-w5-3ed"/>
-                        <constraint firstItem="TCK-eL-kHY" firstAttribute="leading" secondItem="UmH-6k-ovo" secondAttribute="leading" constant="20" id="Fo7-bM-ZzX"/>
+                        <constraint firstItem="UmH-6k-ovo" firstAttribute="leading" secondItem="dMV-bm-I6E" secondAttribute="leading" id="0B2-l2-91d"/>
+                        <constraint firstAttribute="height" relation="lessThanOrEqual" constant="580" id="8FM-xZ-6QJ"/>
+                        <constraint firstItem="UmH-6k-ovo" firstAttribute="top" secondItem="dMV-bm-I6E" secondAttribute="top" id="Elk-II-cSZ"/>
+                        <constraint firstAttribute="bottom" secondItem="UmH-6k-ovo" secondAttribute="bottom" id="aLH-Pp-kIY"/>
+                        <constraint firstAttribute="trailing" secondItem="UmH-6k-ovo" secondAttribute="trailing" id="fXW-d1-Mvk"/>
                     </constraints>
-                    <directionalEdgeInsets key="directionalLayoutMargins" top="32" leading="20" bottom="32" trailing="20"/>
-                </stackView>
+                </view>
             </subviews>
             <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
             <color key="backgroundColor" systemColor="systemBackgroundColor"/>
             <constraints>
-                <constraint firstItem="UmH-6k-ovo" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" id="3Sd-Pm-LDp"/>
-                <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="UmH-6k-ovo" secondAttribute="bottom" id="7vL-xS-WZt"/>
-                <constraint firstItem="UmH-6k-ovo" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="8hf-hG-MY7"/>
-                <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="UmH-6k-ovo" secondAttribute="trailing" id="HXT-HB-Yi4"/>
+                <constraint firstAttribute="bottom" secondItem="teW-tz-jpw" secondAttribute="bottom" id="6tD-Af-seS"/>
+                <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="teW-tz-jpw" secondAttribute="trailing" id="9Mq-sP-CgR"/>
+                <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="dMV-bm-I6E" secondAttribute="trailing" id="DZ1-xY-ViQ"/>
+                <constraint firstItem="teW-tz-jpw" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="top" id="JlD-ei-wbg"/>
+                <constraint firstItem="dMV-bm-I6E" firstAttribute="bottom" secondItem="i5M-Pr-FkT" secondAttribute="bottom" constant="580" id="cKF-Q8-oHT"/>
+                <constraint firstItem="teW-tz-jpw" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="rft-mr-WaS"/>
+                <constraint firstItem="dMV-bm-I6E" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="zyU-gU-ZGm"/>
             </constraints>
             <point key="canvasLocation" x="128.98550724637681" y="143.97321428571428"/>
         </view>

--- a/PokemonDictionary/PokemonDictionary/Search/SearchViewController.swift
+++ b/PokemonDictionary/PokemonDictionary/Search/SearchViewController.swift
@@ -21,7 +21,8 @@ class SearchViewController: UIViewController {
             self.viewModel.moveToDestinationVC = { viewModel in
                 let destVC = PokemonDetailsViewController(nibName: "PokemonDetailsViewController", bundle: nil)
                 destVC.viewModel = viewModel
-                self.navigationController?.pushViewController(destVC, animated: true)
+                destVC.modalPresentationStyle = .overCurrentContext
+                self.present(destVC, animated: false, completion: nil)
             }
         }
     }


### PR DESCRIPTION
* 컨텐츠 사이즈에 맞는 바텀시트 형태로 띄워집니다.
* 바텀시트 바깥쪽을 탭하면 dismiss되고, 화면 전체에서 panning을 해도 일정 높이 이하에서 dismiss됩니다.
* 바텀시트가 띄워지고 움직이는 모든 UI에 부드러운 애니메이션이 설정되어 있습니다.